### PR TITLE
Update initial-profile.ts

### DIFF
--- a/lib/initial-profile.ts
+++ b/lib/initial-profile.ts
@@ -22,7 +22,7 @@ export const initialProfile = async () => {
   const newProfile = await db.profile.create({
     data: {
       userId: user.id,
-      name: `${user.firstName} ${user.lastName}`,
+      name: `${user.firstName}${user.lastName ? " " + user.lastName : ""}`,
       imageUrl: user.imageUrl,
       email: user.emailAddresses[0].emailAddress
     }


### PR DESCRIPTION
last name not added to name if it is null

Checked for null to last name, if there is null in last name its not saved to name column.

#1 

![image](https://github.com/AntonioErdeljac/next13-discord-clone/assets/61489414/03b9d3f0-5b0a-42dc-bfcb-b32368d06027)


```
  const newProfile = await db.profile.create({
    data: {
      userId: user.id,
      name: `${user.firstName} ${user.lastName || ""}`,
      imageUrl: user.imageUrl,
      email: user.emailAddresses[0].emailAddress
    }
  });
  ```
  
  cant do it this way due to a extra whitespace before the check.
