### PR TITLE
Sidebars hidden on redirect fix

### DIFF
--- a/app/(main)/(routes)/servers/[serverId]/layout.tsx
+++ b/app/(main)/(routes)/servers/[serverId]/layout.tsx
@@ -36,7 +36,7 @@ const ServerIdLayout = async ({
   return ( 
     <div className="h-full">
       <div 
-      className="hidden md:flex h-full w-60 z-20 flex-col fixed inset-y-0">
+      className="server-sidebar">
         <ServerSidebar serverId={params.serverId} />
       </div>
       <main className="h-full md:pl-60">

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -7,7 +7,7 @@ const MainLayout = async ({
 }) => {
   return ( 
     <div className="h-full">
-      <div className="hidden md:flex h-full w-[72px] z-30 flex-col fixed inset-y-0">
+      <div className="navigation-sidebar">
         <NavigationSidebar />
       </div>
       <main className="md:pl-[72px] h-full">

--- a/app/globals.css
+++ b/app/globals.css
@@ -80,3 +80,12 @@ body,
     @apply bg-background text-foreground;
   }
 }
+
+@layer components {
+  .navigation-sidebar {
+    @apply hidden md:flex h-full w-[72px] z-30 flex-col fixed inset-y-0;
+  }
+  .server-sidebar {
+    @apply hidden md:flex h-full w-60 z-20 flex-col fixed inset-y-0;
+  }
+}


### PR DESCRIPTION
I don't think it's a real fix, but at least the navigation and the server sidebar are visible when redirected from anywhere by `next/navigation` as discussed in #18 